### PR TITLE
hides API key in .env file

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,8 +1,5 @@
 $(document).ready(function() {
   let script = document.createElement('script');
-  // script.src = `https://maps.googleapis.com/maps/api/js?key=AIzaSyDOP0Ldl0bxMH2NTDlWDEiyONO5rnUd8m8&callback=initMap`;
-  script.src = `https://maps.googleapis.com/maps/api/js?key=AIzaSyA2JE3t0K1wOr-7PzidLQpqCfON6CFflA0&callback=initMap`;
-  script.async = true;
 
   // Attach your callback function to the `window` object
   window.initMap = function() {

--- a/server.js
+++ b/server.js
@@ -49,7 +49,11 @@ app.use("/maps", mapsRoutes());
 // Separate them into separate routes files (see above).
 
 app.get("/", (req, res) => {
-  res.render("index");
+  const templateVars = {
+    apiKey: process.env.API_KEY
+  }
+
+  res.render("index", templateVars);
 });
 
 app.get('/login/:id', (req, res) => {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -53,7 +53,7 @@
 
   </div> -->
 
-  <div class="card flex" style="width: 20vw;">
+  <div class="card flex" style="width: 50vw; height: 50vw;">
     <div id="map" class="flex">
     <!-- Map goes here -->
     </div>
@@ -63,6 +63,11 @@
       <a href="#" class="btn btn-primary">Go somewhere</a>
     </div>
   </div>
+
+  <script
+  src="https://maps.googleapis.com/maps/api/js?key=<%= apiKey %>&callback=initMap"
+  async
+></script>
 </body>
 
 </html>


### PR DESCRIPTION
Hey everyone, here's my solution for using EJS to hide the API key. I moved the <script> creation from the main.js and went back to adding the script in the HTML served in index.ejs. 

add this to your .env file:
`API_KEY=theActualApiKey`

Let me know if you guys are okay with this. Feel free to pull this branch as well and try to make sure it does work on your end.